### PR TITLE
Enable coverage runs for projects using Ran

### DIFF
--- a/core/src/main/java/io/ran/Clazz.java
+++ b/core/src/main/java/io/ran/Clazz.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 
 public class Clazz<T> {
 
+	private static final String COVERAGE_FIELD_PATTERN = "__\\$.*\\$__";
+
 	public static Clazz of(Type type) {
 		if (type instanceof ParameterizedType) {
 			ParameterizedType parameterizedType = ((ParameterizedType) type);
@@ -256,7 +258,9 @@ public class Clazz<T> {
 		Property.PropertyList fields = Property.list();
 
 		for (Field field : getFields()) {
-
+			if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+				continue;
+			}
 			Token token = Token.camelHump(field.getName());
 			Clazz<?> fieldType = Clazz.of(field);
 			Property<?> property = Property.get(token,fieldType);

--- a/core/src/main/java/io/ran/MappingClassWriter.java
+++ b/core/src/main/java/io/ran/MappingClassWriter.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class MappingClassWriter extends AutoMapperClassWriter {
+	private static final String COVERAGE_FIELD_PATTERN = "__\\$.*\\$__";
 	Clazz mapperClazz;
 	public MappingClassWriter(Class clazz) {
 		super(clazz);
@@ -91,6 +92,9 @@ public class MappingClassWriter extends AutoMapperClassWriter {
 			ce.objectStore(3);
 			List<String> fields = new ArrayList<>();
 			for (Field field : aClass.getDeclaredFields()) {
+				if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+					continue;
+				}
 				Token column = Token.camelHump(field.getName());
 				Method getter = aClass.getMethod((field.getType().isPrimitive() && field.getType().equals(boolean.class) ? "is":"get") + column.javaGetter());
 
@@ -145,6 +149,9 @@ public class MappingClassWriter extends AutoMapperClassWriter {
 			ce.objectStore(3);
 			List<String> fields = new ArrayList<>();
 			for (Field field : aClass.getDeclaredFields()) {
+				if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+					continue;
+				}
 				Token column = Token.camelHump(field.getName());
 				Method setter = aClass.getMethod("set" + column.javaGetter(), field.getType());
 				MethodSignature setterInfo = new MethodSignature(setter);
@@ -262,6 +269,9 @@ public class MappingClassWriter extends AutoMapperClassWriter {
 			cec.objectStore(3);
 
 			for (Field field : (List<Field>)clazz.getFields()) {
+				if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+					continue;
+				}
 				Clazz<?> fieldClazz = Clazz.of(field);
 				Token column = Token.camelHump(field.getName());
 				Method fieldMethod = aClass.getMethod((field.getType().isPrimitive() && field.getType().equals(boolean.class) ? "is":"get") + column.javaGetter());
@@ -362,7 +372,9 @@ public class MappingClassWriter extends AutoMapperClassWriter {
 			List<String> fields = new ArrayList<>();
 
 			for (Field field : aClass.getDeclaredFields()) {
-
+				if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+					continue;
+				}
 				Token column = Token.camelHump(field.getName());
 				Method fieldMethod = aClass.getMethod((field.getType().isPrimitive() && field.getType().equals(boolean.class) ? "is":"get") + column.javaGetter());
 				if (Clazz.isPropertyField(field)) {
@@ -422,6 +434,9 @@ public class MappingClassWriter extends AutoMapperClassWriter {
 			}
 
 			for (Field field : aClass.getDeclaredFields()) {
+				if(field.getName().matches(COVERAGE_FIELD_PATTERN)) {
+					continue;
+				}
 				Token column = Token.camelHump(field.getName());
 				Method fieldMethod = aClass.getMethod((field.getType().isPrimitive() && field.getType().equals(boolean.class) ? "is":"get") + column.javaGetter());
 				if (!Clazz.isPropertyField(field)) {


### PR DESCRIPTION
Adds a check so that ran does not modify any fields which matches the format usually used by coverage runners to inject fields.

The following matcher is used:
`__\$.*\$__`
An example field is:
`__$lineHits$__`