### PR TITLE
OPEN-36 When calling relations setters set the relation as loaded

### DIFF
--- a/ran-core/build.gradle
+++ b/ran-core/build.gradle
@@ -11,6 +11,8 @@ repositories {
 
 
 dependencies {
+    testCompile 'org.mockito:mockito-core:3.1.0'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.google.inject', name: 'guice', version: '4.2.3'
     testCompile 'com.google.code.gson:gson:2.9.0'

--- a/ran-core/src/test/java/io/ran/AutoMapperTest.java
+++ b/ran-core/src/test/java/io/ran/AutoMapperTest.java
@@ -16,6 +16,10 @@ import java.time.ZonedDateTime;
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AutoMapperTest {
 	private AutoMapper mapper;
@@ -258,4 +262,49 @@ public class AutoMapperTest {
 		assertNull(gear.getBikes());
 	}
 
+	@Test
+	public void settersSetsLoadedFlag() throws Throwable {
+		Car car = helper.factory.get(Car.class);
+		car.setId("car id");
+
+
+		Mapping carMapping = (Mapping)car;
+		Resolver mockedResolver = mock(Resolver.class);
+		HeadLights existingHeadlights = helper.factory.get(HeadLights.class);
+		existingHeadlights.setOn("existing headlights on");
+		when(mockedResolver.get(any(), anyString(), any())).thenAnswer(i -> {
+			return existingHeadlights;
+		});
+		car.getClass().getMethod("_resolverInject", Resolver.class).invoke(car, mockedResolver);
+
+		HeadLights headLights = helper.factory.get(HeadLights.class);
+		headLights.setOn("car id");
+		car.setHeadLights(headLights);
+
+		assertSame(headLights, car.getHeadLights());
+
+	}
+
+	@Test
+	public void collectionSettersSetsLoadedFlag() throws Throwable {
+		Car car = helper.factory.get(Car.class);
+		car.setId("car id");
+
+
+		Mapping carMapping = (Mapping)car;
+		Resolver mockedResolver = mock(Resolver.class);
+		Door existingDoor = helper.factory.get(Door.class);
+		existingDoor.setId("existing door id");
+		when(mockedResolver.get(any(), anyString(), any())).thenAnswer(i -> {
+			return Arrays.asList(existingDoor);
+		});
+		car.getClass().getMethod("_resolverInject", Resolver.class).invoke(car, mockedResolver);
+
+		Door door = helper.factory.get(Door.class);
+		door.setId("new car id");
+		car.setDoors(Arrays.asList(door));
+
+		assertSame(door, car.getDoors().get(0));
+
+	}
 }

--- a/ran-core/src/test/java/io/ran/HeadLights.java
+++ b/ran-core/src/test/java/io/ran/HeadLights.java
@@ -12,4 +12,11 @@ public class HeadLights {
 	public void setOn(String on) {
 		this.on = on;
 	}
+
+	@Override
+	public String toString() {
+		return "HeadLights{" +
+				"on='" + on + '\'' +
+				'}';
+	}
 }


### PR DESCRIPTION
Such that if override a relation after loading it from the db, the lazy loading does not kick in