### PR TITLE
Saga 7249

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ran-core/build.gradle
+++ b/ran-core/build.gradle
@@ -10,14 +10,14 @@ repositories {
 
 
 dependencies {
-    testCompile 'org.mockito:mockito-core:3.1.0'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
 
-    testCompile group: 'junit', name: 'junit', version: '4.13.1'
-    testCompile group: 'com.google.inject', name: 'guice', version: '4.2.3'
-    testCompile 'com.google.code.gson:gson:2.9.0'
-    compile 'javax.inject:javax.inject:1'
-    compile group: 'org.ow2.asm', name: 'asm', version: '9.2'
-    compile group: 'org.ow2.asm', name: 'asm-util', version: '9.2'
-    compile 'cglib:cglib:3.3.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation group: 'com.google.inject', name: 'guice', version: '4.2.3'
+    testImplementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'javax.inject:javax.inject:1'
+    implementation group: 'org.ow2.asm', name: 'asm', version: '9.2'
+    implementation group: 'org.ow2.asm', name: 'asm-util', version: '9.2'
+    implementation 'cglib:cglib:3.3.0'
 
 }

--- a/ran-core/src/main/java/io/ran/schema/SchemaBuilder.java
+++ b/ran-core/src/main/java/io/ran/schema/SchemaBuilder.java
@@ -12,18 +12,19 @@ import io.ran.TypeDescriber;
 import io.ran.token.TableToken;
 import io.ran.token.Token;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 public abstract class SchemaBuilder<SB extends SchemaBuilder<SB, TB, CB, IB, ITB>, TB extends TableBuilder<TB, CB, IB>, CB extends ColumnBuilder<CB>, IB extends IndexBuilder<IB>, ITB extends ITableBuilder<TB, CB, IB>> {
-	private SchemaExecutor executor;
+	private final SchemaExecutor executor;
 
 	public SchemaBuilder(SchemaExecutor executor) {
 		this.executor = executor;
 	}
 
-	private List<TableAction> tableActions = new ArrayList<>();
+	private final List<TableAction> tableActions = new ArrayList<>();
 
 	abstract protected TB getTableBuilder();
 
@@ -79,4 +80,8 @@ public abstract class SchemaBuilder<SB extends SchemaBuilder<SB, TB, CB, IB, ITB
 	public void build() {
 		executor.execute(tableActions);
 	}
+
+	public void build(DataSource dataSourceToExecuteOn) {
+		executor.execute(tableActions, dataSourceToExecuteOn);
+	};
 }

--- a/ran-core/src/main/java/io/ran/schema/SchemaExecutor.java
+++ b/ran-core/src/main/java/io/ran/schema/SchemaExecutor.java
@@ -8,8 +8,11 @@
  */
 package io.ran.schema;
 
+import javax.sql.DataSource;
 import java.util.Collection;
 
 public interface SchemaExecutor {
 	void execute(Collection<TableAction> values);
+
+	void execute(Collection<TableAction> tableActions, DataSource dataSourceToExecuteOn);
 }

--- a/ran-core/src/test/java/io/ran/schema/SchemaBuilderTest.java
+++ b/ran-core/src/test/java/io/ran/schema/SchemaBuilderTest.java
@@ -13,6 +13,7 @@ import io.ran.Property;
 import io.ran.token.Token;
 import org.junit.Test;
 
+import javax.sql.DataSource;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.UUID;
@@ -101,6 +102,11 @@ public class SchemaBuilderTest {
 			values.forEach(ta -> {
 				result.append(ta.getAction().apply(ta));
 			});
+		}
+
+		@Override
+		public void execute(Collection<TableAction> tableActions, DataSource dataSourceToExecuteOn) {
+			execute(tableActions);
 		}
 	}
 }

--- a/ran-core/src/test/java/io/ran/schema/SchemaBuilderTest.java
+++ b/ran-core/src/test/java/io/ran/schema/SchemaBuilderTest.java
@@ -14,11 +14,17 @@ import io.ran.token.Token;
 import org.junit.Test;
 
 import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SchemaBuilderTest {
 	TestExecutor executor = new TestExecutor();
@@ -94,8 +100,16 @@ public class SchemaBuilderTest {
 		assertEquals("ALTER TABLE 'TheTable' ADD UNIQUE 'myUnique' ('id1', 'id2');", executor.result.toString());
 	}
 
+	@Test
+	public void build_usesProvidedDatasource() {
+		builder.build(new TestDatasource());
+		assertTrue(executor.wasCalledWithDifferentDatasource);
+	}
+
 	private static class TestExecutor implements SchemaExecutor {
 		StringBuilder result = new StringBuilder();
+
+		Boolean wasCalledWithDifferentDatasource = false;
 
 		@Override
 		public void execute(Collection<TableAction> values) {
@@ -107,6 +121,55 @@ public class SchemaBuilderTest {
 		@Override
 		public void execute(Collection<TableAction> tableActions, DataSource dataSourceToExecuteOn) {
 			execute(tableActions);
+			wasCalledWithDifferentDatasource = true;
+		}
+	}
+
+	private static class TestDatasource implements DataSource {
+
+		@Override
+		public Connection getConnection() throws SQLException {
+			return null;
+		}
+
+		@Override
+		public Connection getConnection(String username, String password) throws SQLException {
+			return null;
+		}
+
+		@Override
+		public PrintWriter getLogWriter() throws SQLException {
+			return null;
+		}
+
+		@Override
+		public void setLogWriter(PrintWriter out) throws SQLException {
+
+		}
+
+		@Override
+		public void setLoginTimeout(int seconds) throws SQLException {
+
+		}
+
+		@Override
+		public int getLoginTimeout() throws SQLException {
+			return 0;
+		}
+
+		@Override
+		public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+			return null;
+		}
+
+		@Override
+		public <T> T unwrap(Class<T> iface) throws SQLException {
+			return null;
+		}
+
+		@Override
+		public boolean isWrapperFor(Class<?> iface) throws SQLException {
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
Changes proposed here are meant to enable development on [this valqueries pr](https://github.com/persequor-com/valqueries-sql/pull/56). We're mainly looking for a way to run `SchemaBuilder.build()` on a different datasource than the one injected in it's `SchemaExecutor`. 

This is part of [SAGA-7249](https://persequor.atlassian.net/jira/software/c/projects/SAGA/boards/25?modal=detail&selectedIssue=SAGA-7249)

[SAGA-7249]: https://persequor.atlassian.net/browse/SAGA-7249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ